### PR TITLE
Make Bukkit getOnlinePlayer method calls return type-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# compile output
+*/target
+
+# IntelliJ files
+.idea
+*.iml
+out
+gen
+
+# eclipse files
+.settings
+.classpath
+.project

--- a/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
+++ b/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
@@ -172,7 +172,7 @@ public class MetricsLite {
         int playerAmount;
         try {
             // around MC 1.8 the return type was changed to a collection from an array,
-            // this keeps errors along the line of Server::getOnlinePlayers method not found
+            // this fixes java.lang.NoSuchMethodError: org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
             Method onlinePlayersMethod = Class.forName("org.bukkit.server").getMethod("getOnlinePlayers");
             playerAmount = onlinePlayersMethod.getReturnType().equals(Collection.class)
                     ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()

--- a/bstats-bukkit/src/main/java/org/bstats/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/Metrics.java
@@ -2,6 +2,7 @@ package org.bstats;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.json.simple.JSONArray;
@@ -13,15 +14,9 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.zip.GZIPOutputStream;
 
@@ -194,7 +189,18 @@ public class Metrics {
      */
     private JSONObject getServerData() {
         // Minecraft specific data
-        int playerAmount = Bukkit.getOnlinePlayers().size();
+        int playerAmount;
+        try {
+            // around MC 1.8 the return type was changed to a collection from an array,
+            // this keeps errors along the line of Server::getOnlinePlayers method not found
+            Method onlinePlayersMethod = Class.forName("org.bukkit.server").getMethod("getOnlinePlayers");
+            playerAmount = onlinePlayersMethod.getReturnType().equals(Collection.class)
+                    ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()
+                    : ((Player[]) onlinePlayersMethod.invoke(Bukkit.getServer())).length
+            ;
+        } catch (Exception e) {
+            playerAmount = Bukkit.getOnlinePlayers().size(); // YOLO if all else fails
+        }
         int onlineMode = Bukkit.getOnlineMode() ? 1 : 0;
         String bukkitVersion = org.bukkit.Bukkit.getVersion();
         bukkitVersion = bukkitVersion.substring(bukkitVersion.indexOf("MC: ") + 4, bukkitVersion.length() - 1);

--- a/bstats-bukkit/src/main/java/org/bstats/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/Metrics.java
@@ -192,7 +192,7 @@ public class Metrics {
         int playerAmount;
         try {
             // around MC 1.8 the return type was changed to a collection from an array,
-            // this keeps errors along the line of Server::getOnlinePlayers method not found
+            // this fixes java.lang.NoSuchMethodError: org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
             Method onlinePlayersMethod = Class.forName("org.bukkit.server").getMethod("getOnlinePlayers");
             playerAmount = onlinePlayersMethod.getReturnType().equals(Collection.class)
                     ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,15 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.1</version>


### PR DESCRIPTION
Around MC 1.8 the return type was changed to a collection from an array. This fixes `java.lang.NoSuchMethodError: org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;` exceptions being thrown on server softwares that still use an array for `Bukkit#getOnlinePlayers`.

PR also adds a `.gitignore` file.