### PR TITLE
Backwards compatible getOnlinePlayers method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.project
+.classpath
+.settings/
+target/

--- a/bstats-bukkit-lite/pom.xml
+++ b/bstats-bukkit-lite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bstats</artifactId>
         <groupId>org.bstats</groupId>
-        <version>1.1</version>
+        <version>1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
+++ b/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
@@ -1,7 +1,9 @@
 package org.bstats;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.json.simple.JSONArray;
@@ -13,7 +15,9 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -160,13 +164,33 @@ public class MetricsLite {
     }
 
     /**
+     * Gets the online players (backwards compatibility)
+     * Based on https://github.com/Hidendra/Plugin-Metrics/blob/master/mods/bukkit/metrics/src/main/java/org/mcstats/Metrics.java#L329-L349
+     * 
+     * @return online player amount
+     */
+    private int getOnlinePlayers() {
+        try {
+            Method onlinePlayerMethod = Server.class.getMethod("getOnlinePlayers");
+            if(onlinePlayerMethod.getReturnType().equals(Collection.class)) {
+                return ((Collection<?>) onlinePlayerMethod.invoke(Bukkit.getServer())).size();
+            } else {
+                return ((Player[]) onlinePlayerMethod.invoke(Bukkit.getServer())).length;
+            }
+        } catch (Exception ex) {
+            Bukkit.getLogger().log(Level.WARNING, "Failed to get the online players:" + ex.getMessage());
+        }
+        return 0;
+    }
+
+    /**
      * Gets the server specific data.
      *
      * @return The server specific data.
      */
     private JSONObject getServerData() {
         // Minecraft specific data
-        int playerAmount = Bukkit.getOnlinePlayers().size();
+        int playerAmount = getOnlinePlayers();
         int onlineMode = Bukkit.getOnlineMode() ? 1 : 0;
         String bukkitVersion = Bukkit.getVersion();
         bukkitVersion = bukkitVersion.substring(bukkitVersion.indexOf("MC: ") + 4, bukkitVersion.length() - 1);

--- a/bstats-bukkit/pom.xml
+++ b/bstats-bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bstats</artifactId>
         <groupId>org.bstats</groupId>
-        <version>1.1</version>
+        <version>1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.bstats</groupId>
     <artifactId>bstats</artifactId>
     <packaging>pom</packaging>
-    <version>1.1</version>
+    <version>1.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is a backport of the backwards compatible way to retrieve the count of the online players. Bukkit returned an array and changed the implementation to a collection in 1.7 I believe.

See https://github.com/Hidendra/Plugin-Metrics/blob/master/mods/bukkit/metrics/src/main/java/org/mcstats/Metrics.java#L329-L349 (credits are in the JavaDocs)

I'm maintaining a project which supports MC 1.5.X up to 1.12-pre2, to avoid an error to be thrown I've backported the fix.

Let me know if I should bump BungeeCord or Sponge versions, too.