### PR TITLE
fix: use correct name for Bukkit server class

### DIFF
--- a/bstats-bukkit/src/main/java/org/bstats/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/Metrics.java
@@ -201,7 +201,7 @@ public class Metrics {
         try {
             // Around MC 1.8 the return type was changed to a collection from an array,
             // This fixes java.lang.NoSuchMethodError: org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
-            Method onlinePlayersMethod = Class.forName("org.bukkit.server").getMethod("getOnlinePlayers");
+            Method onlinePlayersMethod = Class.forName("org.bukkit.Server").getMethod("getOnlinePlayers");
             playerAmount = onlinePlayersMethod.getReturnType().equals(Collection.class)
                     ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()
                     : ((Player[]) onlinePlayersMethod.invoke(Bukkit.getServer())).length;


### PR DESCRIPTION
This is a fix for #3, since the `Class.forName` is case sensitive and the correct interface name is `org.bukkit.Server` with a capital S.