### PR TITLE
Guard system property check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # compile output
-*/target
+target/
 
 # IntelliJ files
 .idea

--- a/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
+++ b/bstats-bukkit-lite/src/main/java/org/bstats/MetricsLite.java
@@ -33,7 +33,7 @@ public class MetricsLite {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});

--- a/bstats-bukkit/src/main/java/org/bstats/Metrics.java
+++ b/bstats-bukkit/src/main/java/org/bstats/Metrics.java
@@ -37,7 +37,7 @@ public class Metrics {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[] { 'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's' });
             final String examplePackage = new String(new byte[] { 'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e' });

--- a/bstats-bungeecord-lite/src/main/java/org/bstats/MetricsLite.java
+++ b/bstats-bungeecord-lite/src/main/java/org/bstats/MetricsLite.java
@@ -38,7 +38,7 @@ public class MetricsLite {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});

--- a/bstats-bungeecord/src/main/java/org/bstats/Metrics.java
+++ b/bstats-bungeecord/src/main/java/org/bstats/Metrics.java
@@ -42,7 +42,7 @@ public class Metrics {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});

--- a/bstats-sponge-lite/src/main/java/org/bstats/MetricsLite.java
+++ b/bstats-sponge-lite/src/main/java/org/bstats/MetricsLite.java
@@ -41,7 +41,7 @@ public class MetricsLite {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});

--- a/bstats-sponge/src/main/java/org/bstats/Metrics.java
+++ b/bstats-sponge/src/main/java/org/bstats/Metrics.java
@@ -44,7 +44,7 @@ public class Metrics {
 
     static {
         // You can use the property to disable the check in your test environment
-        if (!System.getProperty("bstats.relocatecheck").equals("false")) {
+        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
             // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
             final String defaultPackage = new String(new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
             final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});


### PR DESCRIPTION
This fixes #14 

Relocation logic is applied, if
- either the property is not set at all
- or the check is *not* disabled via `false`